### PR TITLE
Fix the npm module installation instructions

### DIFF
--- a/gatsby-theme-ghost-attila/README.md
+++ b/gatsby-theme-ghost-attila/README.md
@@ -52,7 +52,7 @@ If you want to add this blog theme to an existing site, follow these instruction
     module.exports = {
     plugins: [
         {
-        resolve: `@draftbox-co/gatsby-attila-theme-ghost`,
+        resolve: `@draftbox-co/gatsby-theme-ghost-attila`,
         options: {
             siteConfig: {
             siteUrl: `https://your-bog.com`,

--- a/gatsby-theme-ghost-attila/README.md
+++ b/gatsby-theme-ghost-attila/README.md
@@ -40,9 +40,9 @@ If you want to add this blog theme to an existing site, follow these instruction
 1. Install the blog theme
 
     ```bash
-    yarn add @draftbox-co/gatsby-attila-theme-ghost
+    yarn add @draftbox-co/gatsby-theme-ghost-attila
     # or
-    npm install @draftbox-co/gatsby-attila-theme-ghost --save
+    npm install @draftbox-co/gatsby-theme-ghost-attila --save
     ```
 
 2. Add the following configuration to your `gatsby-config.js` file


### PR DESCRIPTION
I just happened to notice the readme doesn't point to the correct [npm module](https://www.npmjs.com/package/@draftbox-co/gatsby-theme-ghost-attila)